### PR TITLE
Fix minor typo in translation for SelectWidget in german volto.po

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -114,7 +114,7 @@ msgstr "Titel"
 #: components/Widget/SelectWidget
 # defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
-msgstr "Wir für den programmierten Zugriff auf das Fieldset verwendet."
+msgstr "Wird für den programmierten Zugriff auf das Fieldset verwendet."
 
 #: helpers/react-select
 # defaultMessage: Use Up and Down to choose options


### PR DESCRIPTION
s/Wir/Wird
The same typo is found in https://github.com/thet/plone-react/blob/d606631e5003f3e135ee7fe5eee8468ea803be81/locales/de/LC_MESSAGES/plone-react.po#L846
in 